### PR TITLE
fix: specify Python runtime version in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "functions": {
     "api/index.py": {
-      "runtime": "@vercel/python"
+      "runtime": "@vercel/python@3.9"
     }
   },
   "rewrites": [


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.ai/code)